### PR TITLE
Add JWT verification and use JWT with SMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ ENV BSS_HSM_RETRIEVAL_DELAY=10
 # Base URL of the OAuth2 server public endpoints to use for non-admin requests
 # like a client (e.g. BSS) requesting an access token after it has been
 # authorized.
-# BSS_OAUTH2_USER_BASE_URL=http://127/0/0/1:4444
+# BSS_OAUTH2_USER_BASE_URL=http://127.0.0.1:4444
 
 # Etcd variables with default values:
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,11 +75,16 @@ ENV BSS_HSM_RETRIEVAL_DELAY=10
 # is disabled.
 # BSS_JWKS_URL=""
 #
-# Base URL of the OAUTH2 server to use for client authorizations when
-# JWT authentication is enabled. This is used to authorize BSS to be
-# able to communicate with protected SMD endpoints when it is queried
-# for a boot script.
-# BSS_OAUTH2_BASE_URL=http://127.0.0.1:4444
+# Base URL of the Oauth2 server admin endpoints to use for client authorizations
+# when JWT authentication is enabled. This is used to authorize BSS via a client
+# credentials grant to be able to communicate with protected SMD endpoints when
+# it is queried for a boot script.
+# BSS_OAUTH2_ADMIN_BASE_URL=http://127.0.0.1:4445
+#
+# Base URL of the OAuth2 server public endpoints to use for non-admin requests
+# like a client (e.g. BSS) requesting an access token after it has been
+# authorized.
+# BSS_OAUTH2_USER_BASE_URL=http://127/0/0/1:4444
 
 # Etcd variables with default values:
 #

--- a/cmd/boot-script-service/main.go
+++ b/cmd/boot-script-service/main.go
@@ -53,11 +53,14 @@ import (
 	"github.com/OpenCHAMI/bss/internal/postgres"
 )
 
-const kvDefaultRetryCount uint64 = 10
-const kvDefaultRetryWait uint64 = 5
-const sqlDefaultRetryCount uint64 = 10
-const sqlDefaultRetryWait uint64 = 5
-const authDefaultRetryCount uint64 = 10
+const (
+	kvDefaultRetryCount   uint64 = 10
+	kvDefaultRetryWait    uint64 = 5
+	sqlDefaultRetryCount  uint64 = 10
+	sqlDefaultRetryWait   uint64 = 5
+	authDefaultRetryCount uint64 = 10
+	authDefaultRetryWait  uint64 = 5
+)
 
 var (
 	httpListen    = ":27778"
@@ -95,6 +98,7 @@ var (
 	notifier            *ScnNotifier
 	useSQL              = false // Use ETCD by default
 	authRetryCount      = authDefaultRetryCount
+	authRetryWait       = authDefaultRetryWait
 	jwksURL             = ""
 	sqlDbOpts           = ""
 	spireServiceURL     = "https://spire-tokens.spire:54440"
@@ -304,6 +308,10 @@ func parseEnvVars() error {
 	if parseErr != nil {
 		errList = append(errList, fmt.Errorf("BSS_AUTH_RETRY_COUNT: %q", parseErr))
 	}
+	parseErr = parseEnv("BSS_AUTH_RETRY_WAIT", &authRetryWait)
+	if parseErr != nil {
+		errList = append(errList, fmt.Errorf("BSS_AUTH_RETRY_WAIT: %q", parseErr))
+	}
 	parseErr = parseEnv("BSS_JWKS_URL", &jwksURL)
 	if parseErr != nil {
 		errList = append(errList, fmt.Errorf("BSS_JWKS_URL: %q", parseErr))
@@ -420,6 +428,7 @@ func parseCmdLine() {
 	flag.UintVar(&hsmRetrievalDelay, "hsm-retrieval-delay", hsmRetrievalDelay, "(BSS_HSM_RETRIEVAL_DELAY) SM Retrieval delay in seconds")
 	flag.UintVar(&sqlPort, "postgres-port", sqlPort, "(BSS_DBPORT) Postgres port")
 	flag.Uint64Var(&authRetryCount, "auth-retry-count", authRetryCount, "(BSS_AUTH_RETRY_COUNT) Retry fetching JWKS public key set")
+	flag.Uint64Var(&authRetryWait, "auth-retry-wait", authRetryWait, "(BSS_AUTH_RETRY_WAIT) Interval in seconds between authentication request attempts")
 	flag.Uint64Var(&sqlRetryCount, "postgres-retry-count", sqlRetryCount, "(BSS_SQL_RETRY_COUNT) Amount of times to retry connecting to Postgres")
 	flag.Uint64Var(&sqlRetryWait, "postgres-retry-wait", sqlRetryCount, "(BSS_SQL_RETRY_WAIT) Interval in seconds between connection attempts to Postgres")
 	flag.Parse()

--- a/cmd/boot-script-service/main.go
+++ b/cmd/boot-script-service/main.go
@@ -256,13 +256,18 @@ func getNotifierURL() string {
 
 // Register OAuth2 client and receive access token
 func requestClientCreds() (client OAuthClient, accessToken string, err error) {
-	var url string
+	var (
+		url  string
+		resp []byte
+	)
+
 	url = oauth2AdminBaseURL + "/admin/clients"
 	log.Printf("Attempting to register OAuth2 client")
 	debugf("Sending request to %s", url)
-	_, err = client.CreateOAuthClient(url)
+	resp, err = client.CreateOAuthClient(url)
 	if err != nil {
 		err = fmt.Errorf("Failed to register OAuth2 client: %v", err)
+		debugf("Response: %v", string(resp))
 		return
 	}
 	log.Printf("Successfully registered OAuth2 client")
@@ -274,6 +279,7 @@ func requestClientCreds() (client OAuthClient, accessToken string, err error) {
 	_, err = client.AuthorizeOAuthClient(url)
 	if err != nil {
 		err = fmt.Errorf("Failed to authorize OAuth2 client: %v", err)
+		debugf("Response: %v", string(resp))
 		return
 	}
 	log.Printf("Successfully authorized OAuth2 client")

--- a/cmd/boot-script-service/main.go
+++ b/cmd/boot-script-service/main.go
@@ -455,12 +455,6 @@ func main() {
 		}
 	}
 
-	_, accessToken, err = requestClientCreds()
-	if err != nil {
-		log.Fatalf("OAuth2 client credentials request failed: %v", err)
-	}
-	log.Printf("Access Token: %v\n", accessToken)
-
 	var svcOpts string
 	if insecure {
 		svcOpts = "insecure,"
@@ -477,6 +471,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Access to SM service %s failed: %v\n", hsmBase, err)
 	}
+	log.Printf("Access Token: %v\n", accessToken)
 
 	notifier = newNotifier(serviceName, nfdBase+"/hmi/v1/subscribe", getNotifierURL(), svcOpts)
 

--- a/cmd/boot-script-service/main.go
+++ b/cmd/boot-script-service/main.go
@@ -480,7 +480,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Access to SM service %s failed: %v\n", hsmBase, err)
 	}
-	log.Printf("Access Token: %v\n", accessToken)
 
 	notifier = newNotifier(serviceName, nfdBase+"/hmi/v1/subscribe", getNotifierURL(), svcOpts)
 

--- a/cmd/boot-script-service/main.go
+++ b/cmd/boot-script-service/main.go
@@ -256,25 +256,25 @@ func getNotifierURL() string {
 // Register OAuth2 client and receive access token
 func requestClientCreds() (client OAuthClient, accessToken string, err error) {
 	var url string = oauth2BaseURL + "/admin/clients"
-	log.Printf("Attempting to register OAuth client")
+	log.Printf("Attempting to register OAuth2 client")
 	debugf("Sending request to %s", url)
 	_, err = client.CreateOAuthClient(url)
 	if err != nil {
-		err = fmt.Errorf("Failed to register OAuth client: %v", err)
+		err = fmt.Errorf("Failed to register OAuth2 client: %v", err)
 		return
 	}
-	log.Printf("Successfully registered OAuth client")
+	log.Printf("Successfully registered OAuth2 client")
 	debugf("Client ID: %s", client.Id)
 
 	url = oauth2BaseURL + "/oauth2/auth"
-	log.Printf("Attempting to authorize OAuth client")
+	log.Printf("Attempting to authorize OAuth2 client")
 	debugf("Sending request to %s", url)
 	_, err = client.AuthorizeOAuthClient(url)
 	if err != nil {
-		err = fmt.Errorf("Failed to authorize OAuth client: %v", err)
+		err = fmt.Errorf("Failed to authorize OAuth2 client: %v", err)
 		return
 	}
-	log.Printf("Successfully authorized OAuth client")
+	log.Printf("Successfully authorized OAuth2 client")
 
 	url = oauth2BaseURL + "/oauth2/token"
 	log.Printf("Attempting to fetch token from authorization server")
@@ -488,7 +488,7 @@ func main() {
 
 	_, accessToken, err = requestClientCreds()
 	if err != nil {
-		log.Fatalf("OAuth client credentials request failed: %v", err)
+		log.Fatalf("OAuth2 client credentials request failed: %v", err)
 	}
 	log.Printf("Access Token: %v\n", accessToken)
 

--- a/cmd/boot-script-service/main.go
+++ b/cmd/boot-script-service/main.go
@@ -96,7 +96,6 @@ var (
 	useSQL              = false // Use ETCD by default
 	authRetryCount      = authDefaultRetryCount
 	jwksURL             = ""
-	accessToken         = ""
 	sqlDbOpts           = ""
 	spireServiceURL     = "https://spire-tokens.spire:54440"
 	oauth2AdminBaseURL  = "http://127.0.0.1:4445"
@@ -252,49 +251,6 @@ func getNotifierURL() string {
 	url := "http://" + notifierURL + notifierEndpoint
 	log.Printf("Notification endpoint: %s", url)
 	return url
-}
-
-// Register OAuth2 client and receive access token
-func requestClientCreds() (client OAuthClient, accessToken string, err error) {
-	var (
-		url  string
-		resp []byte
-	)
-
-	url = oauth2AdminBaseURL + "/admin/clients"
-	log.Printf("Attempting to register OAuth2 client")
-	debugf("Sending request to %s", url)
-	resp, err = client.CreateOAuthClient(url)
-	if err != nil {
-		err = fmt.Errorf("Failed to register OAuth2 client: %v", err)
-		debugf("Response: %v", string(resp))
-		return
-	}
-	log.Printf("Successfully registered OAuth2 client")
-	debugf("Client ID: %s", client.Id)
-
-	url = oauth2AdminBaseURL + "/oauth2/auth"
-	log.Printf("Attempting to authorize OAuth2 client")
-	debugf("Sending request to %s", url)
-	_, err = client.AuthorizeOAuthClient(url)
-	if err != nil {
-		err = fmt.Errorf("Failed to authorize OAuth2 client: %v", err)
-		debugf("Response: %v", string(resp))
-		return
-	}
-	log.Printf("Successfully authorized OAuth2 client")
-
-	url = oauth2PublicBaseURL + "/oauth2/token"
-	log.Printf("Attempting to fetch token from authorization server")
-	debugf("Sending request to %s", url)
-	accessToken, err = client.PerformTokenGrant(url)
-	if err != nil {
-		err = fmt.Errorf("Failed to fetch token from authorization server: %v", err)
-		return
-	}
-	fmt.Printf("Successfully fetched token")
-
-	return
 }
 
 func parseEnvVars() error {

--- a/cmd/boot-script-service/oauth.go
+++ b/cmd/boot-script-service/oauth.go
@@ -293,6 +293,8 @@ func JWTIsValid(jwtStr string) (jwtValid bool, reason, err error) {
 	// fields.
 	// TODO: Add full validation.
 	reason = jwt.Validate(token, jwt.WithClock(nowClock{}))
+	debugf("JWT valid between %v and %v", token.NotBefore(), token.Expiration())
+	debugf("Current time: %v", time.Now())
 	if reason == nil {
 		jwtValid = true
 	} else {

--- a/cmd/boot-script-service/oauth.go
+++ b/cmd/boot-script-service/oauth.go
@@ -267,7 +267,7 @@ func JWTTestAndRefresh() (err error) {
 		log.Printf("No JWT detected, fetching a new one")
 	}
 
-	err = PollClientCreds(authRetryCount, 5)
+	err = PollClientCreds(authRetryCount, authRetryWait)
 	if err != nil {
 		log.Printf("Polling for OAuth2 client credentials failed")
 		return fmt.Errorf("Failed to get access token: %v", err)

--- a/cmd/boot-script-service/oauth.go
+++ b/cmd/boot-script-service/oauth.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Triad National Security, LLC. All rights reserved.
+// Copyright © 2024 Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad

--- a/cmd/boot-script-service/oauth.go
+++ b/cmd/boot-script-service/oauth.go
@@ -22,6 +22,8 @@ import (
 	"net/url"
 )
 
+var accessToken = ""
+
 type OAuthClient struct {
 	http.Client
 	Id                      string
@@ -143,4 +145,55 @@ func QuoteArrayStrings(arr []string) []string {
 		arr[i] = "\"" + v + "\""
 	}
 	return arr
+}
+
+// RequestClientCreds performs the requests to the OAuth2 server to obtain an
+// access token for this client (BSS).
+//
+// 1. Register as OAuth2 client.
+// 2. Authorize OAuth2 client that was created.
+// 3. Obtain access token if OAuth2 client is authorized.
+//
+// Returns the OAuthClient struct containing the client ID, secret, etc. as well
+// as the access token and an error if one occurred.
+func RequestClientCreds() (client OAuthClient, accessToken string, err error) {
+	var (
+		url  string
+		resp []byte
+	)
+
+	url = oauth2AdminBaseURL + "/admin/clients"
+	log.Printf("Attempting to register OAuth2 client")
+	debugf("Sending request to %s", url)
+	resp, err = client.CreateOAuthClient(url)
+	if err != nil {
+		err = fmt.Errorf("Failed to register OAuth2 client: %v", err)
+		debugf("Response: %v", string(resp))
+		return
+	}
+	log.Printf("Successfully registered OAuth2 client")
+	debugf("Client ID: %s", client.Id)
+
+	url = oauth2AdminBaseURL + "/oauth2/auth"
+	log.Printf("Attempting to authorize OAuth2 client")
+	debugf("Sending request to %s", url)
+	_, err = client.AuthorizeOAuthClient(url)
+	if err != nil {
+		err = fmt.Errorf("Failed to authorize OAuth2 client: %v", err)
+		debugf("Response: %v", string(resp))
+		return
+	}
+	log.Printf("Successfully authorized OAuth2 client")
+
+	url = oauth2PublicBaseURL + "/oauth2/token"
+	log.Printf("Attempting to fetch token from authorization server")
+	debugf("Sending request to %s", url)
+	accessToken, err = client.PerformTokenGrant(url)
+	if err != nil {
+		err = fmt.Errorf("Failed to fetch token from authorization server: %v", err)
+		return
+	}
+	fmt.Printf("Successfully fetched token")
+
+	return
 }

--- a/cmd/boot-script-service/oauth.go
+++ b/cmd/boot-script-service/oauth.go
@@ -63,7 +63,7 @@ func (client *OAuthClient) CreateOAuthClient(registerUrl string) ([]byte, error)
 		"state":                      "12345678910"
 	}`)
 
-	req, err := http.NewRequest("POST", registerUrl, bytes.NewBuffer(data))
+	req, err := http.NewRequest(http.MethodPost, registerUrl, bytes.NewBuffer(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %v", err)
 	}
@@ -110,7 +110,7 @@ func (client *OAuthClient) AuthorizeOAuthClient(authorizeUrl string) ([]byte, er
 		"Content-Type":  {"application/x-www-form-urlencoded"},
 	}
 
-	req, err := http.NewRequest("POST", authorizeUrl, bytes.NewBuffer(body))
+	req, err := http.NewRequest(http.MethodPost, authorizeUrl, bytes.NewBuffer(body))
 	req.Header = headers
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %v", err)
@@ -134,7 +134,7 @@ func (client *OAuthClient) PerformTokenGrant(remoteUrl string) (string, error) {
 		"Content-Type":  {"application/x-www-form-urlencoded"},
 		"Authorization": {"Bearer " + client.RegistrationAccessToken},
 	}
-	req, err := http.NewRequest("POST", remoteUrl, bytes.NewBuffer([]byte(body)))
+	req, err := http.NewRequest(http.MethodPost, remoteUrl, bytes.NewBuffer([]byte(body)))
 	req.Header = headers
 	if err != nil {
 		return "", fmt.Errorf("failed to make request: %s", err)

--- a/cmd/boot-script-service/oauth.go
+++ b/cmd/boot-script-service/oauth.go
@@ -212,7 +212,7 @@ func RequestClientCreds() (client OAuthClient, accessToken string, err error) {
 		err = fmt.Errorf("Failed to fetch token from authorization server: %v", err)
 		return
 	}
-	fmt.Printf("Successfully fetched token")
+	log.Printf("Successfully fetched token")
 
 	return
 }

--- a/cmd/boot-script-service/oauth.go
+++ b/cmd/boot-script-service/oauth.go
@@ -1,4 +1,16 @@
-// NOTE: Triad License goes here
+// Copyright © 2023 Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S. Department of Energy/National Nuclear
+// Security Administration. All rights in the program are reserved by Triad
+// National Security, LLC, and the U.S. Department of Energy/National Nuclear
+// Security Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide license
+// in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do
+// so.
+
 package main
 
 import (

--- a/cmd/boot-script-service/sm.go
+++ b/cmd/boot-script-service/sm.go
@@ -106,7 +106,7 @@ func TestSMAuthEnabled(retryCount, retryInterval uint64) (authEnabled bool, err 
 	}
 	for retry := uint64(0); retry < retryCount; retry++ {
 		log.Printf("Attempting connection to %s (attempt %d/%d)", testURL, retry+1, retryCount)
-		resp, err = http.Get(testURL)
+		resp, err = smClient.Get(testURL)
 		if err != nil {
 			err = fmt.Errorf("Could not GET %q: %v", testURL, err)
 			time.Sleep(retryDuration)
@@ -147,7 +147,7 @@ func TestSMProtectedAccess() error {
 		"Authorization": {"Bearer " + accessToken},
 	}
 	req.Header = headers
-	res, err = http.DefaultClient.Do(req)
+	res, err = smClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("Could not execute request: %v")
 	}
@@ -218,7 +218,7 @@ func SmOpen(base, options string) error {
 	}
 	if smAuthEnabled {
 		log.Printf("HSM authenticated endpoints enabled, checking token")
-		err = JWTTestAndRefresh()
+		err = smClient.JWTTestAndRefresh()
 		if err != nil {
 			return fmt.Errorf("Failed refreshing JWT: %v", err)
 		}
@@ -277,7 +277,7 @@ func getStateFromHSM() *SMData {
 			return nil
 		}
 		if authEnabled {
-			err = JWTTestAndRefresh()
+			err = smClient.JWTTestAndRefresh()
 			if err != nil {
 				log.Printf("Failed to refresh JWT: %v", err)
 				return nil

--- a/cmd/boot-script-service/sm.go
+++ b/cmd/boot-script-service/sm.go
@@ -91,6 +91,11 @@ func TestSMAuthEnabled(retryCount, retryInterval uint64) (authEnabled bool, err 
 		resp    *http.Response
 	)
 
+	if smClient == nil {
+		err = fmt.Errorf("smClient nil. Has a connection been opened yet?")
+		return
+	}
+
 	// If this endpoint is protected (querying it returns a 401),
 	// auth is enabled.
 	testURL, err = url.JoinPath(smBaseURL, hsmTestEP)
@@ -134,6 +139,9 @@ func TestSMProtectedAccess() error {
 
 	if accessToken == "" {
 		return fmt.Errorf("Access token is empty")
+	}
+	if smClient == nil {
+		return fmt.Errorf("smClient nil. Has a connection been opened yet?")
 	}
 
 	testURL, err := url.JoinPath(smBaseURL, hsmTestEP)

--- a/cmd/boot-script-service/sm.go
+++ b/cmd/boot-script-service/sm.go
@@ -129,7 +129,7 @@ func TestSMProtectedAccess() error {
 		return err
 	}
 
-	req, err = http.NewRequest("GET", testURL, nil)
+	req, err = http.NewRequest(http.MethodGet, testURL, nil)
 	headers := map[string][]string{
 		"Authorization": {"Bearer " + accessToken},
 	}

--- a/cmd/boot-script-service/sm.go
+++ b/cmd/boot-script-service/sm.go
@@ -70,7 +70,7 @@ type SMData struct {
 var (
 	smMutex     sync.Mutex
 	smData      *SMData
-	smClient    *http.Client
+	smClient    *OAuthClient
 	smDataMap   map[string]SMComponent
 	smBaseURL   string
 	smJSONFile  string
@@ -198,7 +198,7 @@ func SmOpen(base, options string) error {
 		}
 	}
 	// Using the Datastore service
-	smClient = new(http.Client)
+	smClient = new(OAuthClient)
 	if https && insecure {
 		tcfg := new(tls.Config)
 		tcfg.InsecureSkipVerify = true

--- a/cmd/boot-script-service/sm.go
+++ b/cmd/boot-script-service/sm.go
@@ -205,31 +205,9 @@ func SmOpen(base, options string) error {
 	}
 	if smAuthEnabled {
 		log.Printf("HSM authenticated endpoints enabled, checking token")
-		if accessToken == "" {
-			log.Printf("No access token, requesting one from OAuth2 server")
-			err = PollClientCreds(authRetryCount, 5)
-			if err != nil {
-				log.Printf("Polling for OAuth2 client credentials failed")
-				return fmt.Errorf("Failed to get access token for HSM: %v", err)
-			}
-		}
-		log.Printf("Checking JWT validity")
-		var jwtValid bool
-		var reason error
-		jwtValid, reason, err = JWTIsValid(accessToken)
+		err = JWTTestAndRefresh()
 		if err != nil {
-			return fmt.Errorf("Error checking JWT validity: %v", err)
-		} else if !jwtValid {
-			log.Printf("JWT is not valid, reason: %v", reason)
-			log.Printf("Attempting to obtain new JWT")
-			err = PollClientCreds(authRetryCount, 5)
-			if err != nil {
-				log.Printf("Polling for OAuth2 client credentials failed")
-				return fmt.Errorf("Failed to get access token for HSM: %v", err)
-			}
-			log.Printf("Successfully obtained new JWT")
-		} else {
-			log.Printf("JWT is valid")
+			return fmt.Errorf("Failed refreshing JWT: %v", err)
 		}
 	}
 	return nil

--- a/cmd/boot-script-service/sm.go
+++ b/cmd/boot-script-service/sm.go
@@ -324,7 +324,7 @@ func getStateFromHSM() *SMData {
 
 		url = smBaseURL + "/Inventory/ComponentEndpoints?type=Node"
 		req, rerr = http.NewRequest(http.MethodGet, url, nil)
-		if err != nil {
+		if rerr != nil {
 			log.Printf("Failed to create HTTP request for '%s': %v", url, rerr)
 			return nil
 		}
@@ -394,7 +394,7 @@ func getStateFromHSM() *SMData {
 		//ip address
 		url = smBaseURL + "/Inventory/EthernetInterfaces?type=Node"
 		req, rerr = http.NewRequest(http.MethodGet, url, nil)
-		if err != nil {
+		if rerr != nil {
 			log.Printf("Failed to create HTTP request for '%s': %v", url, rerr)
 			return nil
 		}

--- a/cmd/boot-script-service/sm.go
+++ b/cmd/boot-script-service/sm.go
@@ -112,6 +112,7 @@ func TestSMAuthEnabled(retryCount, retryInterval uint64) (authEnabled bool, err 
 			time.Sleep(retryDuration)
 			continue
 		}
+		log.Printf("Connected to %s on attempt %d", testURL, retry+1)
 		if resp.StatusCode == 401 {
 			authEnabled = true
 		} else {


### PR DESCRIPTION
Add functionality in BSS to:

- Verify if SMD has authentication enabled
- Validate its own JWT to see if it needs to fetch a new one (and fetch it)
  - Right now validation is simply that the JWT hasn't expired and is after the nbf field
- Present a valid JWT when requesting SMD protected endpoints

Also:

- Add Triad license